### PR TITLE
Add support for specifying regions with a BED file

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,23 +75,24 @@ tabix output.tsv.gz chr1:5-10
 
 Usage:
 
-```bash
-Usage: perbase simple-depth <reads> [-r <ref-fasta>] [-o <output>] [-t <threads>] [-f <include-flags>] [-F <exclude-flags>] [-q <min-mapq>]
+```text
+Usage: perbase simple-depth <reads> [-r <ref-fasta>] [-b <bed-file>] [-o <output>] [-t <threads>] [-c <chunksize>] [-f <include-flags>] [-F <exclude-flags>] [-q <min-mapq>]
 
-Calculate the depth at each base, per-nucleotide.
-
-Arguments:
-  reads             indexed BAM/CRAM file
+Calculate the depth at each base, per-nucleotide. Takes an indexed BAM/CRAM as <reads>.
 
 Options:
   -r, --ref-fasta   indexed reference fasta, set if using CRAM
-  -o, --output      output path, defaults to stdout
-  -t, --threads     the number of threads to use
+  -b, --bed-file    a BED file containing regions of interest. If specified,
+                    only bases from the given regions will be reported on
+  -o, --output      output path. DEFAULT: stdout
+  -t, --threads     the number of threads to use. DEFAULT: max_available
+  -c, --chunksize   the ideal number of basepairs each worker receives. Total bp
+                    in memory at one time is (threads - 2) * chunksize
   -f, --include-flags
-                    SAM flags to include
+                    SAM flags to include. DEFAULT: 0
   -F, --exclude-flags
-                    SAM flags to exclude
-  -q, --min-mapq    minimum mapq for a read to count toward depth
+                    SAM flags to exclude, recommended 3848. DEFAULT: 0
+  -q, --min-mapq    minimum mapq for a read to count toward depth. DEFAULT: 0
   --help            display usage information
 ```
 
@@ -100,4 +101,3 @@ Options:
 - [ ] Add more metrics to match `bam-readcount` as an `indepth` tool
 - [ ] Add a strictly depth calculation a la `mosdepth` as an `onlydepth`
 - [ ] Add bgzip output / auto tabix indexing support
-- [ ] Support limiting inputs with an interval_list file

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -1,1 +1,2 @@
+pub mod par_io;
 pub mod utils;

--- a/src/lib/par_io.rs
+++ b/src/lib/par_io.rs
@@ -1,0 +1,210 @@
+//! A Helper module for iterating over regions of a BAM/CRAM file in parallel,
+//! operating on the at region, and printing a result.
+use anyhow::Result;
+use bio::io::bed;
+use crossbeam::channel::unbounded;
+use grep_cli::stdout;
+use log::*;
+use num_cpus;
+use rayon::prelude::*;
+use rust_htslib::bam::{HeaderView, IndexedReader, Read};
+use rust_lapper::{Interval, Lapper};
+use serde::Serialize;
+use std::{
+    fs::File,
+    io::{BufWriter, Write},
+    path::PathBuf,
+    thread,
+};
+use termcolor::ColorChoice;
+
+#[derive(Debug)]
+pub struct ParIO {
+    /// Path to an indexed BAM / CRAM file
+    reads: PathBuf,
+    /// Optional reference file for CRAM
+    ref_fasta: Option<PathBuf>,
+    /// Optional path to a BED file to restrict the regions iterated over
+    regions_bed: Option<PathBuf>,
+    /// Optional path to an output file, STDOUT will be used if None
+    output_file: Option<PathBuf>,
+    /// Number of threads this is allowed to use, uses all if None
+    threads: usize,
+    /// The ideal number of basepairs each worker will receive. Total bp in memory at one time = `threads` * `chunksize`
+    chunksize: usize,
+}
+
+impl ParIO {
+    /// Create a ParIO object
+    pub fn new(
+        reads: PathBuf,
+        ref_fasta: Option<PathBuf>,
+        regions_bed: Option<PathBuf>,
+        output_file: Option<PathBuf>,
+        threads: Option<usize>,
+        chunksize: Option<usize>,
+    ) -> Self {
+        let threads = if let Some(threads) = threads {
+            threads
+        } else {
+            num_cpus::get()
+        };
+
+        let chunksize = if let Some(chunksize) = chunksize {
+            chunksize
+        } else {
+            1_000_000
+        };
+        info!("Using {} worker threads.", threads);
+        info!("Using chunksize of {}.", chunksize);
+        Self {
+            reads,
+            ref_fasta,
+            regions_bed,
+            output_file,
+            threads,
+            chunksize,
+        }
+    }
+
+    /// Open a CSV Writer to a file or stdout
+    fn get_writer(&self) -> Result<csv::Writer<Box<dyn Write>>> {
+        let raw_writer: Box<dyn Write> = match &self.output_file {
+            Some(path) if path.to_str().unwrap() != "-" => {
+                Box::new(BufWriter::new(File::open(path)?))
+            }
+            _ => Box::new(stdout(ColorChoice::Never)),
+        };
+        Ok(csv::WriterBuilder::new()
+            .delimiter(b'\t')
+            .from_writer(raw_writer))
+    }
+
+    /// Process each region.
+    ///
+    /// This method splits the sequences in the BAM/CRAM header into `chunksize` * `self.threads` regions (aka 'super chunks').
+    /// It then queries that 'super chunk' against the intervals (either the BED file, or the whole genome broken up into `chunksize`
+    /// regions). The results of that query are then processed by a pool of workers that apply `process_region` to reach interval to
+    /// do perbase analysis on.
+    ///
+    /// While one 'super chunk' is being worked on by all workers, the last 'super chunks' results are being printed to either to
+    /// a file or to STDOUT, in order.
+    ///
+    /// # Arguments
+    ///
+    /// - `process_region`: a function that takes the tid, start, and stop and returns something serializable
+    /// - `chunksize`: optional agrgument to change the default chunksize of 1_000_000. `chunksize` determines the number of bases
+    ///                each worker will get to work on at one time.
+    pub fn process<S, F>(self, process_region: F) -> Result<()>
+    where
+        S: 'static + Serialize + Send + Sync,
+        F: 'static + Fn(u32, usize, usize) -> Vec<S> + Send + Sync,
+    {
+        let mut writer = self.get_writer()?;
+
+        let (snd, rxv) = unbounded();
+        thread::spawn(move || {
+            info!("Reading from {:?}", self.reads);
+            let mut reader = IndexedReader::from_path(&self.reads).expect("Indexed BAM/CRAM");
+            // If passed add ref_fasta
+            if let Some(ref_fasta) = &self.ref_fasta {
+                reader.set_reference(ref_fasta).expect("Set ref");
+            }
+            // Get a copy of the header
+            let header = reader.header().to_owned();
+
+            let intervals = if let Some(regions_bed) = &self.regions_bed {
+                Self::bed_to_intervals(&header, regions_bed).expect("Parsed BED to intervals")
+            } else {
+                Self::header_to_intervals(&header, self.chunksize)
+                    .expect("Parsed BAM/CRAM header to intervals")
+            };
+
+            // The number positions to try to process in one batch
+            let serial_step_size = self.chunksize * self.threads; // aka superchunk
+            for (tid, intervals) in intervals.into_iter().enumerate() {
+                let tid: u32 = tid as u32;
+                let tid_end = header.target_len(tid).unwrap() as usize;
+                // Result holds the processed positions to be sent to writer
+                let mut result = vec![];
+                for chunk_start in (0..tid_end).step_by(serial_step_size) {
+                    let chunk_end = std::cmp::min(chunk_start + serial_step_size, tid_end);
+                    info!("Batch Processing {}:{}-{}", tid, chunk_start, chunk_end);
+                    let (r, _): (Vec<S>, ()) = rayon::join(
+                        || {
+                            // Must be a vec so that par_iter works and results stay in order
+                            let ivs: Vec<Interval<()>> = intervals
+                                .find(chunk_start as u32, chunk_end as u32)
+                                .map(|iv| iv.clone())
+                                .collect();
+                            ivs.into_par_iter()
+                                .flat_map(|iv| {
+                                    process_region(tid, iv.start as usize, iv.stop as usize)
+                                })
+                                .collect()
+                        },
+                        || {
+                            result.into_iter().for_each(|s: S| {
+                                snd.send(s).expect("Sent a serializable to writer")
+                            })
+                        },
+                    );
+                    result = r;
+                }
+                // Send final set of results
+                result
+                    .into_iter()
+                    .for_each(|s: S| snd.send(s).expect("Sent a serializable to writer"));
+            }
+        });
+        rxv.into_iter()
+            .for_each(|pos| writer.serialize(pos).unwrap());
+        writer.flush()?;
+        Ok(())
+    }
+
+    // Convert the header into intervals of equally sized chunks. The last interval may be short.
+    fn header_to_intervals(header: &HeaderView, chunksize: usize) -> Result<Vec<Lapper<()>>> {
+        let mut intervals = vec![vec![]; header.target_count() as usize];
+        for tid in 0..(header.target_count() as usize) {
+            let tid_len = header.target_len(tid as u32).unwrap() as usize;
+            for start in (0..tid_len).step_by(chunksize) {
+                let stop = std::cmp::min(start + chunksize, tid_len);
+                intervals[tid].push(Interval::<()> {
+                    start: start as u32,
+                    stop: stop as u32,
+                    val: (),
+                });
+            }
+        }
+        Ok(intervals.into_iter().map(|ivs| Lapper::new(ivs)).collect())
+    }
+
+    /// Read a bed file into a vector of lappers with the index representing the TID
+    // TODO add a proper error message
+    // TODO update rust_lapper to use u64
+    fn bed_to_intervals(header: &HeaderView, bed_file: &PathBuf) -> Result<Vec<Lapper<()>>> {
+        let mut bed_reader = bed::Reader::from_file(bed_file)?;
+        let mut intervals = vec![vec![]; header.target_count() as usize];
+        for record in bed_reader.records() {
+            let record = record?;
+            let tid = header
+                .tid(record.chrom().as_bytes())
+                .expect("Chromosome not found in BAM/CRAM header");
+            intervals[tid as usize].push(Interval::<()> {
+                start: record.start() as u32,
+                stop: record.end() as u32,
+                val: (),
+            });
+        }
+
+        Ok(intervals
+            .into_iter()
+            .map(|ivs| {
+                let mut lapper = Lapper::new(ivs);
+                lapper.merge_overlaps();
+                lapper
+            })
+            .collect())
+    }
+}


### PR DESCRIPTION
This also cleans up the parallel reader / writer code and makes it reusable. 