### PR TITLE
Bugfix/multi count regions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perbase"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Seth Stadick <sstadick@gmail.com>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
When an interval overlapped a superchunk start/end the interval would
get counted multiple times. Now those overhanging intervals are
truncated to fit within the superchunk.