### PR TITLE
Feature/ref base

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -620,6 +620,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru_time_cache"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebac060fafad3adedd0c66a80741a92ff4bc8e94a273df2ba3770ab206f2e29a"
+
+[[package]]
 name = "lzma-sys"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,6 +788,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "log",
+ "lru_time_cache",
  "num_cpus",
  "proptest",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ rust-lapper = "0.5.0"
 itertools = "0.9.0"
 structopt = "0.3.18"
 lazy_static = "1.4.0"
+lru_time_cache = "0.11.1"
 
 [dev-dependencies]
 rstest = "0.6.4"

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The output columns are as follows:
 | -------- | -------------------------------------------------------------------------------------------------- |
 | REF      | The reference sequence name                                                                        |
 | POS      | The position on the reference sequence                                                             |
+| REF_BASE | The reference base at the position, column excluded if no reference was supplied                   |
 | DEPTH    | The total depth at the position SUM(A, C, T, G, DEL)                                               |
 | A        | Total A nucleotides seen at this position                                                          |
 | C        | Total C nucleotides seen at this position                                                          |
@@ -59,27 +60,22 @@ perbase base-depth ./test/test.bam
 Example output
 
 ```text
-REF     POS     DEPTH   A       C       G       T       N       INS     DEL     FAIL    REF_SKIP
-chr2    1       1       1       0       0       0       0       0       0       0       0
-chr2    2       1       1       0       0       0       0       1       0       0       0
-chr2    3       1       0       0       1       0       0       0       0       0       0
-chr2    4       1       1       0       0       0       0       0       0       0       0
-chr2    5       2       2       0       0       0       0       0       0       0       0
-chr2    6       2       2       0       0       0       0       0       0       0       0
-chr2    7       2       1       0       0       0       0       0       1       0       0
-chr2    8       2       1       0       0       0       0       0       1       0       0
-chr2    9       2       1       0       0       0       0       0       1       0       0
-chr2    10      3       2       0       0       0       0       0       1       0       0
-chr2    11      3       2       0       0       0       0       0       1       0       0
-chr2    12      3       3       0       0       0       0       0       0       0       0
-chr2    13      3       2       0       0       0       0       0       0       0       1
-chr2    14      3       2       0       0       0       0       0       0       0       1
-chr2    15      4       3       0       0       0       0       0       0       0       1
-chr2    16      4       2       0       0       1       0       0       0       0       1
-chr2    17      4       3       0       0       0       0       0       0       0       1
+REF     POS     REF_BASE        DEPTH   A       C       G       T       N       INS     DEL     REF_SKIP        FAIL
+chr1    709636  T       16      0       0       0       16      0       0       0       0       0
+chr1    709637  T       16      0       4       0       12      0       0       0       0       0
+chr1    709638  A       16      16      0       0       0       0       0       0       0       0
+chr1    709639  G       16      0       0       16      0       0       0       0       0       0
+chr1    709640  A       16      16      0       0       0       0       0       0       0       0
+chr1    709641  A       16      16      0       0       0       0       0       0       0       0
+chr1    709642  G       16      0       0       16      0       0       0       0       0       0
+chr1    709643  G       16      0       0       16      0       0       0       0       0       0
+chr1    709644  T       16      0       0       0       16      0       0       0       0       0
+chr1    709645  G       16      0       0       16      0       0       0       0       0       0
 ```
 
 If the `--mate-fix` flag is passed, each position will first check if there are any mate overlaps and choose the mate with the hightest MAPQ, breaking ties by choosing the first mate that passes filters. Mates that are discarded are not counted toward `FAIL` or `DEPTH`.
+
+If the `--reference-fasta` is supplied, the `REF_BASE` field will be filled in. The reference must be indexed an match the BAM/CRAM header of the input.
 
 The output can be compressed and indexed as follows:
 
@@ -93,6 +89,8 @@ tabix output.tsv.gz chr1:5-10
 Usage:
 
 ```text
+perbase-base-depth 0.3.9-alpha.0
+Seth Stadick <sstadick@gmail.com>
 Calculate the depth at each base, per-nucleotide
 
 USAGE:
@@ -105,16 +103,18 @@ FLAGS:
     -z, --zero-base    Output positions as 0-based instead of 1-based
 
 OPTIONS:
-    -b, --bed-file <bed-file>              A BED file containing regions of interest. If specified, only bases from the
-                                           given regions will be reported on
-    -c, --chunksize <chunksize>            The ideal number of basepairs each worker receives. Total bp in memory at one
-                                           time is (threads - 2) * chunksize
-    -F, --exclude-flags <exclude-flags>    SAM flags to exclude, recommended 3848 [default: 0]
-    -f, --include-flags <include-flags>    SAM flags to include [default: 0]
-    -q, --min-mapq <min-mapq>              Minimum MAPQ for a read to count toward depth [default: 0]
-    -o, --output <output>                  Output path, defaults to stdout
-    -r, --ref-fasta <ref-fasta>            Indexed reference fasta, set if using CRAM
-    -t, --threads <threads>                The number of threads to use [default: 16]
+    -b, --bed-file <bed-file>                A BED file containing regions of interest. If specified, only bases from
+                                             the given regions will be reported on
+    -c, --chunksize <chunksize>              The ideal number of basepairs each worker receives. Total bp in memory at
+                                             one time is (threads - 2) * chunksize
+    -F, --exclude-flags <exclude-flags>      SAM flags to exclude, recommended 3848 [default: 0]
+    -f, --include-flags <include-flags>      SAM flags to include [default: 0]
+    -q, --min-mapq <min-mapq>                Minimum MAPQ for a read to count toward depth [default: 0]
+    -o, --output <output>                    Output path, defaults to stdout
+        --ref-cache-size <ref-cache-size>    Number of Reference Sequences to hold in memory at one time. Smaller will
+                                             decrease mem usage [default: 10]
+    -r, --ref-fasta <ref-fasta>              Indexed reference fasta, set if using CRAM
+    -t, --threads <threads>                  The number of threads to use [default: 16]
 
 ARGS:
     <reads>    Input indexed BAM/CRAM to analyze

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -121,4 +121,5 @@
 pub mod par_granges;
 pub mod position;
 pub mod read_filter;
+pub mod reference;
 pub mod utils;

--- a/src/lib/position/pileup_position.rs
+++ b/src/lib/position/pileup_position.rs
@@ -21,6 +21,7 @@ pub struct PileupPosition {
     /// 1-based position in the sequence.
     pub pos: usize,
     /// The reference base at this position.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ref_base: Option<char>,
     /// Total depth at this position.
     pub depth: usize,

--- a/src/lib/position/pileup_position.rs
+++ b/src/lib/position/pileup_position.rs
@@ -20,6 +20,8 @@ pub struct PileupPosition {
     pub ref_seq: String,
     /// 1-based position in the sequence.
     pub pos: usize,
+    /// The reference base at this position.
+    pub ref_base: Option<char>,
     /// Total depth at this position.
     pub depth: usize,
     /// Number of A bases at this position.
@@ -43,7 +45,7 @@ pub struct PileupPosition {
     pub fail: usize,
 }
 
-impl Position  for PileupPosition {
+impl Position for PileupPosition {
     /// Create a new position for the given ref_seq name.
     fn new(ref_seq: String, pos: usize) -> Self {
         PileupPosition {
@@ -53,7 +55,6 @@ impl Position  for PileupPosition {
         }
     }
 }
-
 
 impl PileupPosition {
     /// Given a record, update the counts at this position

--- a/src/lib/reference.rs
+++ b/src/lib/reference.rs
@@ -1,0 +1,51 @@
+//! A module for handling cacheing requests for reference sequences.
+//!
+//! Borrowed from https://github.com/varlociraptor/varlociraptor/blob/master/src/reference.rs
+use std::fs;
+use std::str;
+use std::sync::Arc;
+use std::sync::{Mutex, RwLock};
+
+use anyhow::Result;
+use bio::io::fasta;
+use lru_time_cache::LruCache;
+
+/// A lazy buffer for reference sequences.
+pub struct Buffer {
+    reader: RwLock<fasta::IndexedReader<fs::File>>,
+    sequences: Mutex<LruCache<String, Arc<Vec<u8>>>>,
+}
+
+impl Buffer {
+    /// Create a new Reference Buffer. Capacity is the number of reference sequences to hold in the cache at one time.
+    pub fn new(fasta: fasta::IndexedReader<fs::File>, capacity: usize) -> Self {
+        Buffer {
+            reader: RwLock::new(fasta),
+            sequences: Mutex::new(LruCache::with_capacity(capacity)),
+        }
+    }
+
+    /// Get a Vec of all the sequences in the Reference
+    pub fn sequences(&self) -> Vec<fasta::Sequence> {
+        self.reader.read().unwrap().index.sequences()
+    }
+
+    /// Load given chromosome and return it as a slice. This is O(1) if chromosome was loaded before.
+    pub fn seq(&self, chrom: &str) -> Result<Arc<Vec<u8>>> {
+        let mut sequences = self.sequences.lock().unwrap();
+
+        if !sequences.contains_key(chrom) {
+            let mut sequence = Arc::new(Vec::new());
+            {
+                let mut reader = self.reader.write().unwrap();
+                reader.fetch_all(chrom)?;
+                reader.read(Arc::get_mut(&mut sequence).unwrap())?;
+            }
+
+            sequences.insert(chrom.to_owned(), Arc::clone(&sequence));
+            Ok(sequence)
+        } else {
+            Ok(Arc::clone(sequences.get(chrom).unwrap()))
+        }
+    }
+}


### PR DESCRIPTION
Now prints the ref-base in the `base-depth` tool if the `reference-fasta` was passed in. 