### PR TITLE
Set max depth to max i32

### DIFF
--- a/src/commands/base_depth.rs
+++ b/src/commands/base_depth.rs
@@ -16,6 +16,7 @@ use perbase_lib::{
 };
 use rust_htslib::{bam, bam::Read};
 use std::{
+    convert::TryInto,
     fs::File,
     io::{BufWriter, Write},
     path::PathBuf,
@@ -193,8 +194,9 @@ impl<F: ReadFilter> RegionProcessor for BaseProcessor<F> {
         // fetch the region of interest
         reader.fetch(tid, start, stop).expect("Fetched a region");
         // Walk over pileups
-        let result: Vec<PileupPosition> = reader
-            .pileup()
+        let mut pileup = reader.pileup();
+        pileup.set_max_depth(i32::max_value().try_into().unwrap());
+        let result: Vec<PileupPosition> = pileup
             .flat_map(|p| {
                 let pileup = p.expect("Extracted a pileup");
                 // Verify that we are within the bounds of the chunk we are iterating on


### PR DESCRIPTION
The pileup created by htslib seems to default to about 8000 max depth, the same as `samtools mpileup` if you don't add a `-d` flag. This PR sets it the `i32::max_value()` which I think it the more expected behavior, this could cause memory issues with very high depth bams. But I still think that is more expected and those bams should be down sampled with a different tool rather than a hard cutoff here. 

only `base-depth` is affected by this change. All other tools don't rely on pileup engine. 