### PR TITLE
Feature/vcf and maxdepth support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aho-corasick"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b476ce7103678b0c6d3d395dbbae31d48ff910bd28be979ba5d48c6351131d0d"
+checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
 dependencies = [
  "memchr",
 ]
@@ -20,9 +20,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.33"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1fd36ffbb1fb7c834eac128ea8d0e310c5aeb635548f9d58861e1308d46e71c"
+checksum = "bf8dcb5b4bbaa28653b647d8c77bd4ed40183b48882e130c1f1ffb73de069fd7"
 
 [[package]]
 name = "approx"
@@ -177,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.61"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed67cbde08356238e75fc4656be4749481eeffb09e19f320a25237d5221c985d"
+checksum = "f1770ced377336a88a67c473594ccc14eca6f4559217c34f64aac8f83d641b40"
 dependencies = [
  "jobserver",
 ]
@@ -213,9 +213,9 @@ dependencies = [
 
 [[package]]
 name = "const_fn"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce90df4c658c62f12d78f7508cf92f9173e5184a539c10bfe54a3107b3ffd0f2"
+checksum = "c478836e029dcef17fb47c89023448c64f781a046e0300e257ad8225ae59afab"
 
 [[package]]
 name = "crossbeam"
@@ -338,9 +338,9 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00affe7f6ab566df61b4be3ce8cf16bc2576bca0963ceb0955e45d514bf9a279"
+checksum = "fc4666154fd004af3fd6f1da2e81a96fd5a81927fe8ddb6ecc79e2aa6e138b54"
 dependencies = [
  "bstr",
  "csv-core",
@@ -453,6 +453,16 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
 
 [[package]]
 name = "fs-utils"
@@ -850,6 +860,7 @@ dependencies = [
  "lru_time_cache",
  "num_cpus",
  "proptest",
+ "rand",
  "rayon",
  "rstest",
  "rust-htslib",
@@ -885,9 +896,9 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "proc-macro-error"
@@ -1046,9 +1057,9 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "regex"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8963b85b8ce3074fecffde43b4b0dded83ce2f367dc8d363afc56679f3ee820b"
+checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1067,9 +1078,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.20"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cab7a364d15cde1e505267766a2d3c4e22a843e1a601f0fa7564c0f82ced11c"
+checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
 
 [[package]]
 name = "remove_dir_all"
@@ -1352,18 +1363,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "318234ffa22e0920fe9a40d7b8369b5f649d490980cf7aadcf1eb91594869b42"
+checksum = "0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae2447b6282786c3493999f40a9be2a6ad20cb8bd268b0a0dbf5a065535c0ab"
+checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1429,10 +1440,11 @@ checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "url"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
+checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
 dependencies = [
+ "form_urlencoded",
  "idna",
  "matches",
  "percent-encoding",

--- a/examples/par_granges_example.rs
+++ b/examples/par_granges_example.rs
@@ -84,11 +84,12 @@ fn main() -> Result<()> {
 
     // Create a par_granges runner
     let par_granges_runner = par_granges::ParGranges::new(
-        PathBuf::from("test/test.bam"),       // pass in bam
-        None,                                 // optional ref fasta
+        PathBuf::from("test/test.bam"),             // pass in bam
+        None,                                   // optional ref fasta
+        None,                                 // optional bcf/vcf file to specify positions of interest
         Some(PathBuf::from("test/test.bed")), // bedfile to narrow regions
-        None,                                 // optional allowed number of threads, defaults to max
-        None,                                 // optional chunksize modification
+        None,                                    // optional allowed number of threads, defaults to max
+        None,                                  // optional chunksize modification
         basic_processor,
     );
 

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -98,6 +98,7 @@
 //!     let par_granges_runner = par_granges::ParGranges::new(
 //!         PathBuf::from("test/test.bam"),       // pass in bam
 //!         None,                                 // optional ref fasta
+//!         None,                                 // optional bcf/vcf file specifying positions of interest
 //!         Some(PathBuf::from("test/test.bed")), // bedfile to narrow regions
 //!         None,                                 // optional allowed number of threads, defaults to max
 //!         None,                                 // optional chunksize modification

--- a/src/lib/par_granges.rs
+++ b/src/lib/par_granges.rs
@@ -257,7 +257,7 @@ impl<R: RegionProcessor + Send + Sync> ParGranges<R> {
 
     /// Read a BCF/VCF file into a vector of lappers with index representing the TID
     fn bcf_to_intervals(header: &HeaderView, bcf_file: &PathBuf) -> Result<Vec<Lapper<u64, ()>>> {
-        let mut bcf_reader = Reader::from_path(bcf_file).expect("Error openging BCF/VCF file.");
+        let mut bcf_reader = Reader::from_path(bcf_file).expect("Error opening BCF/VCF file.");
         let bcf_header_reader = Reader::from_path(bcf_file).expect("Error openging BCF/VCF file.");
         let bcf_header = bcf_header_reader.header();
         let mut intervals = vec![vec![]; header.target_count() as usize];

--- a/src/lib/par_granges.rs
+++ b/src/lib/par_granges.rs
@@ -258,7 +258,7 @@ impl<R: RegionProcessor + Send + Sync> ParGranges<R> {
     /// Read a BCF/VCF file into a vector of lappers with index representing the TID
     fn bcf_to_intervals(header: &HeaderView, bcf_file: &PathBuf) -> Result<Vec<Lapper<u64, ()>>> {
         let mut bcf_reader = Reader::from_path(bcf_file).expect("Error opening BCF/VCF file.");
-        let bcf_header_reader = Reader::from_path(bcf_file).expect("Error openging BCF/VCF file.");
+        let bcf_header_reader = Reader::from_path(bcf_file).expect("Error opening BCF/VCF file.");
         let bcf_header = bcf_header_reader.header();
         let mut intervals = vec![vec![]; header.target_count() as usize];
         // TODO: validate the headers against eachother

--- a/src/lib/position/pileup_position.rs
+++ b/src/lib/position/pileup_position.rs
@@ -44,6 +44,8 @@ pub struct PileupPosition {
     pub ref_skip: usize,
     /// Number of reads failing filters at this position.
     pub fail: usize,
+    /// Depth is within 1% of max_depth
+    pub near_max_depth: bool
 }
 
 impl Position for PileupPosition {


### PR DESCRIPTION
This adds support for taking a BCF/VCF file to specify the positions of
interest. It also allows a user to specify the max depth in order to
help control runtime in cases where there is very high coverage.

This also includes a bugfix to `only-depth` that was skipping records
that started on the stop of a region, or stopped on the start of a
region.

Lastly, this adds the full contig name to the logs for better debuging,
and clarifies when tid is output instead of the contig name