### PR TITLE
Feature/bound channels

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,4 +18,4 @@ jobs:
       - name: Build
         run: cargo build --verbose
       - name: Run tests
-        run: cargo test --verbose -- --ignore
+        run: cargo test --verbose -- --ignored

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,21 +2,20 @@ name: Rust
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - uses: actions/checkout@v2
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose -- --ignore

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,4 +18,4 @@ jobs:
       - name: Build
         run: cargo build --verbose
       - name: Run tests
-        run: cargo test --verbose -- --ignored
+        run: cargo test --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,9 +566,8 @@ dependencies = [
 
 [[package]]
 name = "hts-sys"
-version = "1.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7548557013f78aeae1ed2cb5cd2417f4f95d224c875da445facc516a16d914e5"
+version = "1.11.0"
+source = "git+https://github.com/rust-bio/rust-htslib?branch=master#7e85484fa3863fb5d59061e727d4ca8f1613646f"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -599,12 +598,6 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
-
-[[package]]
-name = "ieee754"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9007da9cacbd3e6343da136e98b0d2df013f553d35bdec8b518f07bea768e19c"
 
 [[package]]
 name = "indexmap"
@@ -1105,14 +1098,12 @@ dependencies = [
 
 [[package]]
 name = "rust-htslib"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0cc6875ef87204babb9a02918942d325a834bdd173d94187d0f38a487cba185"
+version = "0.34.1-alpha.0"
+source = "git+https://github.com/rust-bio/rust-htslib?branch=master#7e85484fa3863fb5d59061e727d4ca8f1613646f"
 dependencies = [
  "bio-types",
  "custom_derive",
  "hts-sys",
- "ieee754",
  "lazy_static",
  "libc",
  "linear-map",
@@ -1391,9 +1382,18 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "0.3.4"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117"
+checksum = "b78a366903f506d2ad52ca8dc552102ffdd3e937ba8a227f024dc1d1eae28575"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "triple_accel"
@@ -1412,18 +1412,18 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb19cf769fa8c6a80a162df694621ebeb4dafb606470b2b2fce0be40a98a977"
+checksum = "b7f98e67a4d84f730d343392f9bfff7d21e3fca562b9cb7a43b768350beeddc6"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
+checksum = "db8716a166f290ff49dabc18b44aa407cb7c6dbe1aa0971b44b8a24b0ca35aae"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ name = "perbase"
 path = "src/main.rs"
 
 [dependencies]
-rust-htslib = "0.32.0"
+rust-htslib = { git = "https://github.com/rust-bio/rust-htslib", branch = "master" }
 log = "0.4.11"
 env_logger = "0.7.1"
 anyhow = "1.0.32"

--- a/examples/par_granges_example.rs
+++ b/examples/par_granges_example.rs
@@ -90,6 +90,7 @@ fn main() -> Result<()> {
         Some(PathBuf::from("test/test.bed")), // bedfile to narrow regions
         None,                                    // optional allowed number of threads, defaults to max
         None,                                  // optional chunksize modification
+        None,                        // optional modifier on the size of the channel for sending Positions
         basic_processor,
     );
 

--- a/examples/par_granges_example.rs
+++ b/examples/par_granges_example.rs
@@ -49,7 +49,7 @@ impl<F: ReadFilter> RegionProcessor for BasicProcessor<F> {
         let mut reader = bam::IndexedReader::from_path(&self.bamfile).expect("Indexed reader");
         let header = reader.header().to_owned();
         // fetch the region
-        reader.fetch(tid, start, stop).expect("Fetched ROI");
+        reader.fetch((tid, start, stop)).expect("Fetched ROI");
         // Walk over pileups
         let result: Vec<PileupPosition> = reader
             .pileup()

--- a/src/commands/base_depth.rs
+++ b/src/commands/base_depth.rs
@@ -55,7 +55,7 @@ pub struct BaseDepth {
     #[structopt(long, short = "c", default_value=par_granges::CHUNKSIZE_STR.as_str())]
     chunksize: usize,
 
-    /// The fraction of a gigabyte to allocate per thread, can be greater than 1.0.
+    /// The fraction of a gigabyte to allocate per thread for message passing, can be greater than 1.0.
     #[structopt(long, short="C", default_value=par_granges::CHANNEL_SIZE_MODIFIER_STR.as_str())]
     channel_size_modifier: f64,
 

--- a/src/commands/base_depth.rs
+++ b/src/commands/base_depth.rs
@@ -51,6 +51,10 @@ pub struct BaseDepth {
     #[structopt(long, short = "t", default_value = utils::NUM_CPU.as_str())]
     threads: usize,
 
+    /// A modifier to change the ration of Bytes / thread to allocate to the channel for printing Positions
+    #[structopt(long, short="C")]
+    channel_size_modifier: Option<f64>, // default set by par_granges at 1.0
+
     /// The ideal number of basepairs each worker receives. Total bp in memory at one time is (threads - 2) * chunksize.
     #[structopt(long, short = "c")]
     chunksize: Option<usize>, // default set by par_granges at 1_000_000
@@ -111,6 +115,7 @@ impl BaseDepth {
             self.bcf_file.clone(),
             Some(cpus),
             self.chunksize.clone(),
+            self.channel_size_modifier,
             base_processor,
         );
 
@@ -345,7 +350,7 @@ mod tests {
             BaseProcessor::new(bamfile.0.clone(), None, false, 1, read_filter, 500_000,cpus);
 
         let par_granges_runner =
-            par_granges::ParGranges::new(bamfile.0, None, None, None, Some(cpus), None, base_processor);
+            par_granges::ParGranges::new(bamfile.0, None, None, None, Some(cpus), None, Some(0.001), base_processor);
         let mut positions = HashMap::new();
         par_granges_runner
             .process()
@@ -377,7 +382,7 @@ mod tests {
         );
 
         let par_granges_runner =
-            par_granges::ParGranges::new(bamfile.0, None, None, None, Some(cpus), None, base_processor);
+            par_granges::ParGranges::new(bamfile.0, None, None, None, Some(cpus), None,Some(0.001), base_processor);
         let mut positions = HashMap::new();
         par_granges_runner
             .process()

--- a/src/commands/base_depth.rs
+++ b/src/commands/base_depth.rs
@@ -211,7 +211,7 @@ impl<F: ReadFilter> RegionProcessor for BaseProcessor<F> {
 
         let header = reader.header().to_owned();
         // fetch the region of interest
-        reader.fetch(tid, start, stop).expect("Fetched a region");
+        reader.fetch((tid, start, stop)).expect("Fetched a region");
         // Walk over pileups
         let mut pileup = reader.pileup();
         pileup.set_max_depth(std::cmp::min(i32::max_value().try_into().unwrap(), self.max_depth));

--- a/src/commands/base_depth.rs
+++ b/src/commands/base_depth.rs
@@ -56,7 +56,7 @@ pub struct BaseDepth {
     chunksize: usize,
 
     /// The fraction of a gigabyte to allocate per thread for message passing, can be greater than 1.0.
-    #[structopt(long, short="C", default_value=par_granges::CHANNEL_SIZE_MODIFIER_STR.as_str())]
+    #[structopt(long, short="C", default_value="0.15")]
     channel_size_modifier: f64,
 
     /// SAM flags to include.

--- a/src/commands/base_depth.rs
+++ b/src/commands/base_depth.rs
@@ -51,13 +51,13 @@ pub struct BaseDepth {
     #[structopt(long, short = "t", default_value = utils::NUM_CPU.as_str())]
     threads: usize,
 
-    /// A modifier to change the ration of Bytes / thread to allocate to the channel for printing Positions
-    #[structopt(long, short="C")]
-    channel_size_modifier: Option<f64>, // default set by par_granges at 1.0
-
     /// The ideal number of basepairs each worker receives. Total bp in memory at one time is (threads - 2) * chunksize.
-    #[structopt(long, short = "c")]
-    chunksize: Option<usize>, // default set by par_granges at 1_000_000
+    #[structopt(long, short = "c", default_value=par_granges::CHUNKSIZE_STR.as_str())]
+    chunksize: usize,
+
+    /// The fraction of a gigabyte to allocate per thread, can be greater than 1.0.
+    #[structopt(long, short="C", default_value=par_granges::CHANNEL_SIZE_MODIFIER_STR.as_str())]
+    channel_size_modifier: f64,
 
     /// SAM flags to include.
     #[structopt(long, short = "f", default_value = "0")]
@@ -114,8 +114,8 @@ impl BaseDepth {
             self.bed_file.clone(),
             self.bcf_file.clone(),
             Some(cpus),
-            self.chunksize.clone(),
-            self.channel_size_modifier,
+            Some(self.chunksize.clone()),
+            Some(self.channel_size_modifier),
             base_processor,
         );
 

--- a/src/commands/base_depth.rs
+++ b/src/commands/base_depth.rs
@@ -55,6 +55,7 @@ pub struct BaseDepth {
     #[structopt(long, short = "c", default_value=par_granges::CHUNKSIZE_STR.as_str())]
     chunksize: usize,
 
+    // NB: If there are large regions of low coverage, bumping this up may be helpful.
     /// The fraction of a gigabyte to allocate per thread for message passing, can be greater than 1.0.
     #[structopt(long, short="C", default_value="0.15")]
     channel_size_modifier: f64,

--- a/src/commands/only_depth.rs
+++ b/src/commands/only_depth.rs
@@ -264,7 +264,7 @@ impl<F: ReadFilter> OnlyDepthProcessor<F> {
 
         let header = reader.header().to_owned();
         // fetch the region of interest
-        reader.fetch(tid, start, stop).expect("Fetched a region");
+        reader.fetch((tid, start, stop)).expect("Fetched a region");
 
         let mut counter: Vec<i32> = vec![0; (stop - start) as usize];
         let mut maties = HashMap::new();
@@ -353,7 +353,7 @@ impl<F: ReadFilter> OnlyDepthProcessor<F> {
 
         let header = reader.header().to_owned();
         // fetch the region of interest
-        reader.fetch(tid, start, stop).expect("Fetched a region");
+        reader.fetch((tid, start, stop)).expect("Fetched a region");
 
         let mut counter: Vec<i32> = vec![0; (stop - start) as usize];
         let mut maties = HashMap::new();

--- a/src/commands/only_depth.rs
+++ b/src/commands/only_depth.rs
@@ -55,12 +55,12 @@ pub struct OnlyDepth {
     threads: usize,
 
     /// The ideal number of basepairs each worker receives. Total bp in memory at one time is (threads - 2) * chunksize.
-    #[structopt(long, short = "c")]
-    chunksize: Option<usize>, // default set by par_granges at 1_000_000
+    #[structopt(long, short = "c", default_value=par_granges::CHUNKSIZE_STR.as_str())]
+    chunksize: usize,
 
-    /// A modifier to change the ration of Bytes / thread to allocate to the channel for printing Positions
-    #[structopt(long, short="C")]
-    channel_size_modifier: Option<f64>, // default set by par_granges at 1.0
+    /// The fraction of a gigabyte to allocate per thread, can be greater than 1.0.
+    #[structopt(long, short="C", default_value=par_granges::CHANNEL_SIZE_MODIFIER_STR.as_str())]
+    channel_size_modifier: f64,
 
     /// SAM flags to include.
     #[structopt(long, short = "f", default_value = "0")]
@@ -116,8 +116,8 @@ impl OnlyDepth {
             self.bed_file.clone(),
             self.bcf_file.clone(),
             Some(cpus),
-            self.chunksize.clone(),
-            self.channel_size_modifier,
+            Some(self.chunksize.clone()),
+            Some(self.channel_size_modifier),
             processor,
         );
 

--- a/src/commands/only_depth.rs
+++ b/src/commands/only_depth.rs
@@ -59,7 +59,7 @@ pub struct OnlyDepth {
     chunksize: usize,
 
     /// The fraction of a gigabyte to allocate per thread for message passing, can be greater than 1.0.
-    #[structopt(long, short="C", default_value="0.01")]
+    #[structopt(long, short="C", default_value="0.001")]
     channel_size_modifier: f64,
 
     /// SAM flags to include.

--- a/src/commands/only_depth.rs
+++ b/src/commands/only_depth.rs
@@ -58,6 +58,10 @@ pub struct OnlyDepth {
     #[structopt(long, short = "c")]
     chunksize: Option<usize>, // default set by par_granges at 1_000_000
 
+    /// A modifier to change the ration of Bytes / thread to allocate to the channel for printing Positions
+    #[structopt(long, short="C")]
+    channel_size_modifier: Option<f64>, // default set by par_granges at 1.0
+
     /// SAM flags to include.
     #[structopt(long, short = "f", default_value = "0")]
     include_flags: u16,
@@ -113,6 +117,7 @@ impl OnlyDepth {
             self.bcf_file.clone(),
             Some(cpus),
             self.chunksize.clone(),
+            self.channel_size_modifier,
             processor,
         );
 
@@ -642,6 +647,7 @@ mod tests {
             None,
             Some(cpus),
             Some(1_000_000),
+            Some(0.001),
             onlydepth_processor,
         );
         let mut positions = HashMap::new();
@@ -673,6 +679,7 @@ mod tests {
             None,
             Some(cpus),
             Some(1_000_000),
+            Some(0.001),
             onlydepth_processor,
         );
         let mut positions = HashMap::new();
@@ -704,6 +711,7 @@ mod tests {
             None,
             Some(cpus),
             Some(1_000_000),
+            Some(0.001),
             onlydepth_processor,
         );
         let mut positions = HashMap::new();
@@ -735,6 +743,7 @@ mod tests {
             None,
             Some(cpus),
             None,
+            Some(0.001),
             onlydepth_processor,
         );
         let mut positions = HashMap::new();
@@ -766,6 +775,7 @@ mod tests {
             None,
             Some(cpus),
             None,
+            Some(0.001),
             onlydepth_processor,
         );
         let mut positions = HashMap::new();

--- a/src/commands/only_depth.rs
+++ b/src/commands/only_depth.rs
@@ -58,7 +58,7 @@ pub struct OnlyDepth {
     #[structopt(long, short = "c", default_value=par_granges::CHUNKSIZE_STR.as_str())]
     chunksize: usize,
 
-    /// The fraction of a gigabyte to allocate per thread, can be greater than 1.0.
+    /// The fraction of a gigabyte to allocate per thread for message passing, can be greater than 1.0.
     #[structopt(long, short="C", default_value=par_granges::CHANNEL_SIZE_MODIFIER_STR.as_str())]
     channel_size_modifier: f64,
 

--- a/src/commands/only_depth.rs
+++ b/src/commands/only_depth.rs
@@ -59,7 +59,7 @@ pub struct OnlyDepth {
     chunksize: usize,
 
     /// The fraction of a gigabyte to allocate per thread for message passing, can be greater than 1.0.
-    #[structopt(long, short="C", default_value=par_granges::CHANNEL_SIZE_MODIFIER_STR.as_str())]
+    #[structopt(long, short="C", default_value="0.01")]
     channel_size_modifier: f64,
 
     /// SAM flags to include.

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -61,7 +61,7 @@
 //!         let mut reader = bam::IndexedReader::from_path(&self.bamfile).expect("Indexed reader");
 //!         let header = reader.header().to_owned();
 //!         // fetch the region
-//!         reader.fetch(tid, start, stop).expect("Fetched ROI");
+//!         reader.fetch((tid, start, stop)).expect("Fetched ROI");
 //!         // Walk over pileups
 //!         let result: Vec<PileupPosition> = reader
 //!             .pileup()

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -102,6 +102,7 @@
 //!         Some(PathBuf::from("test/test.bed")), // bedfile to narrow regions
 //!         None,                                 // optional allowed number of threads, defaults to max
 //!         None,                                 // optional chunksize modification
+//!         None,                                 // optional channel size modification
 //!         basic_processor,
 //!     );
 //!

--- a/src/lib/par_granges.rs
+++ b/src/lib/par_granges.rs
@@ -19,6 +19,7 @@ use lazy_static::lazy_static;
 const BYTES_INA_GIGABYTE: usize = 1024 * 1024 * 1024;
 
 /// A modifier to apply to the channel size formular that is (BYTES_INA_GIGABYTE * channel_size_modifier) * threads / size_of(R::P)
+/// 0.15 roughly corresponds to 1_000_000 PileupPosition objects per thread with some wiggle room.
 pub const CHANNEL_SIZE_MODIFIER: f64 = 0.15;
 
 /// The ideal number of basepairs each worker will receive. Total bp in memory at one time = `threads` * `chunksize`


### PR DESCRIPTION
Add an upper bound to the channel a that connects par_granges to the processors. This prevents running up a huge backlog of positions to print in the even to  very low coverage areas for base-depth.

On low coverage datasets, more space per thread is needed. On high coverage, less since more time is spent on calculations allowing printing to keep up.

The selected defaults were optimized for 100X data to be very near the same time for an unbounded channel. 