### PR TITLE
Performance and OSX builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "bytecount"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0017894339f586ccb943b01b9555de56770c11cda818e7e3d8bd93f4ed7f46e"
+checksum = "c39a773ba75db12126d8d383f1bdbf7eb92ea47ec27dd0557aff1fedf172764c"
 
 [[package]]
 name = "byteorder"
@@ -177,9 +177,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.62"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1770ced377336a88a67c473594ccc14eca6f4559217c34f64aac8f83d641b40"
+checksum = "ad9c6140b5a2c7db40ea56eb1821245e5362b44385c05b76288b1a599934ac87"
 dependencies = [
  "jobserver",
 ]
@@ -380,14 +380,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
 
 [[package]]
+name = "derefable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e519abf1289075763071c981958e89948b079fc54962617a0e6413d9ce44cbe7"
+dependencies = [
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "syn 0.15.44",
+]
+
+[[package]]
 name = "derive-new"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71f31892cd5c62e414316f2963c5689242c43d8e7bbcaaeca97e5e28c95d91d9"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.48",
 ]
 
 [[package]]
@@ -418,9 +429,9 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5c450cf304c9e18d45db562025a14fb1ca0f5c769b6f609309f81d4c31de455"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.48",
 ]
 
 [[package]]
@@ -499,9 +510,9 @@ version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bb3f5b7d8d70c9bd23cf29b2b38094661418fb0ea79f1b0cc2019a11d6f5429"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.48",
 ]
 
 [[package]]
@@ -566,8 +577,9 @@ dependencies = [
 
 [[package]]
 name = "hts-sys"
-version = "1.11.0"
-source = "git+https://github.com/rust-bio/rust-htslib?branch=master#7e85484fa3863fb5d59061e727d4ca8f1613646f"
+version = "1.11.1-fix1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d376f20f3cef2b8e0612c4931dc992f7850882fcfda4dfaa2a0c172f43b3352d"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -598,6 +610,12 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
+
+[[package]]
+name = "ieee754"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9007da9cacbd3e6343da136e98b0d2df013f553d35bdec8b518f07bea768e19c"
 
 [[package]]
 name = "indexmap"
@@ -899,9 +917,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.48",
  "version_check",
 ]
 
@@ -911,9 +929,18 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
  "version_check",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
+dependencies = [
+ "unicode-xid 0.1.0",
 ]
 
 [[package]]
@@ -922,7 +949,7 @@ version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
- "unicode-xid",
+ "unicode-xid 0.2.1",
 ]
 
 [[package]]
@@ -953,11 +980,20 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
+dependencies = [
+ "proc-macro2 0.4.30",
+]
+
+[[package]]
+name = "quote"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
- "proc-macro2",
+ "proc-macro2 1.0.24",
 ]
 
 [[package]]
@@ -1090,20 +1126,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec448bc157977efdc0a71369cf923915b0c4806b1b2449c3fb011071d6f7c38"
 dependencies = [
  "cfg-if 0.1.10",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
  "rustc_version 0.2.3",
- "syn",
+ "syn 1.0.48",
 ]
 
 [[package]]
 name = "rust-htslib"
-version = "0.34.1-alpha.0"
-source = "git+https://github.com/rust-bio/rust-htslib?branch=master#7e85484fa3863fb5d59061e727d4ca8f1613646f"
+version = "0.35.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32238e34bd0ef9111c345350092cefe81228dbb666b217597452241d5e18c945"
 dependencies = [
  "bio-types",
  "custom_derive",
+ "derefable",
+ "derive-new",
  "hts-sys",
+ "ieee754",
  "lazy_static",
  "libc",
  "linear-map",
@@ -1209,9 +1249,9 @@ version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.48",
 ]
 
 [[package]]
@@ -1240,9 +1280,9 @@ version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7073448732a89f2f3e6581989106067f403d378faeafb4a50812eb814170d3e5"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.48",
 ]
 
 [[package]]
@@ -1285,9 +1325,9 @@ checksum = "65e51c492f9e23a220534971ff5afc14037289de430e3c83f9daf6a1b6ae91e8"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.48",
 ]
 
 [[package]]
@@ -1303,9 +1343,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87c85aa3f8ea653bfd3ddf25f7ee357ee4d204731f6aa9ad04002306f6e2774c"
 dependencies = [
  "heck",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.48",
+]
+
+[[package]]
+name = "syn"
+version = "0.15.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
+dependencies = [
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "unicode-xid 0.1.0",
 ]
 
 [[package]]
@@ -1314,9 +1365,9 @@ version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
 dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "unicode-xid 0.2.1",
 ]
 
 [[package]]
@@ -1335,9 +1386,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
 ]
@@ -1366,9 +1417,9 @@ version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.48",
 ]
 
 [[package]]
@@ -1382,9 +1433,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b78a366903f506d2ad52ca8dc552102ffdd3e937ba8a227f024dc1d1eae28575"
+checksum = "ccf8dbc19eb42fba10e8feaaec282fb50e2c14b2726d6301dbfeed0f73306a6f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1412,9 +1463,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f98e67a4d84f730d343392f9bfff7d21e3fca562b9cb7a43b768350beeddc6"
+checksum = "a13e63ab62dbe32aeee58d1c5408d35c36c392bba5d9d3142287219721afe606"
 dependencies = [
  "tinyvec",
 ]
@@ -1430,6 +1481,12 @@ name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+
+[[package]]
+name = "unicode-xid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ name = "perbase"
 path = "src/main.rs"
 
 [dependencies]
-rust-htslib = { git = "https://github.com/rust-bio/rust-htslib", branch = "master" }
+rust-htslib = "0.35.2"
 log = "0.4.11"
 env_logger = "0.7.1"
 anyhow = "1.0.32"

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -57,7 +57,7 @@
 //!     type P = PileupPosition;
 //!
 //!     // This function receives an interval to examine.
-//!     fn process_region(&self, tid: u32, start: u64, stop: u64) -> Vec<Self::P> {
+//!     fn process_region(&self, tid: u32, start: u32, stop: u32) -> Vec<Self::P> {
 //!         let mut reader = bam::IndexedReader::from_path(&self.bamfile).expect("Indexed reader");
 //!         let header = reader.header().to_owned();
 //!         // fetch the region
@@ -69,7 +69,7 @@
 //!                 let pileup = p.expect("Extracted a pileup");
 //!                 // Verify that we are within the bounds of the chunk we are iterating on
 //!                 // Since pileup will pull reads that overhang edges.
-//!                 if (pileup.pos() as u64) >= start && (pileup.pos() as u64) < stop {
+//!                 if pileup.pos() >= start && pileup.pos() < stop {
 //!                     Some(PileupPosition::from_pileup(pileup, &header, &self.read_filter))
 //!                 } else {
 //!                     None

--- a/src/lib/position/mod.rs
+++ b/src/lib/position/mod.rs
@@ -8,6 +8,6 @@ use smartstring::alias::String;
 /// A serializable object meant to hold all information about a position.
 pub trait Position: Default + Serialize {
     /// Create a new position with all other values zeroed
-    fn new(ref_seq: String, pos: usize) -> Self;
+    fn new(ref_seq: String, pos: u32) -> Self;
 }
 

--- a/src/lib/position/range_positions.rs
+++ b/src/lib/position/range_positions.rs
@@ -4,7 +4,7 @@
 use crate::position::Position;
 use serde::Serialize;
 use smartstring::alias::String;
-use std::{default};
+use std::default;
 
 /// Hold all information about a range of positions.
 #[derive(Debug, Serialize, Default)]
@@ -14,16 +14,16 @@ pub struct RangePositions {
     #[serde(rename = "REF")]
     pub ref_seq: String,
     /// 1-based position in the sequence.
-    pub pos: usize,
+    pub pos: u32,
     /// The point at which this depth ends, non-inclusive
-    pub end: usize,
+    pub end: u32,
     /// Total depth at this position.
-    pub depth: usize,
+    pub depth: u32,
 }
 
 impl Position for RangePositions {
     /// Create a new position for the given ref_seq name.
-    fn new(ref_seq: String, pos: usize) -> Self {
+    fn new(ref_seq: String, pos: u32) -> Self {
         RangePositions {
             ref_seq,
             pos,

--- a/src/lib/read_filter.rs
+++ b/src/lib/read_filter.rs
@@ -1,7 +1,5 @@
 //! A trait and default implementation of a read filter.
-use rust_htslib::bam::{
-    record::Record,
-};
+use rust_htslib::bam::record::Record;
 
 /// Anything that implements ReadFilter can apply a filter set to read.
 pub trait ReadFilter {
@@ -27,9 +25,9 @@ impl DefaultReadFilter {
     }
 }
 
-impl ReadFilter for DefaultReadFilter{
+impl ReadFilter for DefaultReadFilter {
     /// Filter reads based SAM flags and mapping quality
-    #[inline]
+    #[inline(always)]
     fn filter_read(&self, read: &Record) -> bool {
         let flags = read.flags();
         (!flags) & &self.include_flags == 0
@@ -37,4 +35,3 @@ impl ReadFilter for DefaultReadFilter{
             && &read.mapq() >= &self.min_mapq
     }
 }
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 extern crate perbase_lib;
 pub mod commands;
 use anyhow::Result;
-// use argh::FromArgs;
 use commands::*;
 use env_logger::Env;
 use log::*;


### PR DESCRIPTION
Modest improvements in both memory usage and runtime via rightsizing structs, in-lining, and using rc_records for bam iteration.

This also bumps the version of rust-htslib