### PR TITLE
[feature] pre-v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -55,7 +55,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -66,10 +66,11 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "bio"
-version = "0.32.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1161c7b80eea668a884b4be136d83ef5175df5aaa6dcba482bdf4fbe1d046f2"
+checksum = "59d3ff3414dbcb87e7e389c769287b06ee55f65c8f0be582152003657c77b7b7"
 dependencies = [
+ "anyhow",
  "approx",
  "bio-types",
  "bit-set",
@@ -91,14 +92,14 @@ dependencies = [
  "num-traits",
  "ordered-float",
  "petgraph",
- "quick-error",
+ "rand 0.8.4",
  "regex",
  "serde",
  "serde_derive",
- "snafu",
  "statrs",
  "strum",
- "strum_macros 0.18.0",
+ "strum_macros",
+ "thiserror",
  "triple_accel",
  "vec_map",
 ]
@@ -112,7 +113,7 @@ dependencies = [
  "derive-new",
  "lazy_static",
  "regex",
- "strum_macros 0.20.1",
+ "strum_macros",
  "thiserror",
 ]
 
@@ -150,6 +151,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
+
+[[package]]
 name = "bv"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,6 +177,12 @@ name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bytes"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "bzip2-sys"
@@ -193,12 +206,6 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
-name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -219,36 +226,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7b858541263efe664aead4a5209a4ae5c5d2811167d4ed4ee0944503f8d2089"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "core_affinity"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f8a03115cc34fb0d7c321dd154a3914b3ca082ccc5c11d91bf7117dbbe7171f"
+dependencies = [
+ "kernel32-sys",
+ "libc",
+ "num_cpus",
+ "winapi 0.2.8",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
 name = "crossbeam"
-version = "0.7.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e"
+checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
 dependencies = [
- "cfg-if 0.1.10",
- "crossbeam-channel 0.4.4",
- "crossbeam-deque 0.7.3",
- "crossbeam-epoch 0.8.2",
+ "cfg-if",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
  "crossbeam-queue",
- "crossbeam-utils 0.7.2",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
-dependencies = [
- "crossbeam-utils 0.7.2",
- "maybe-uninit",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -257,19 +275,8 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils 0.8.5",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
-dependencies = [
- "crossbeam-epoch 0.8.2",
- "crossbeam-utils 0.7.2",
- "maybe-uninit",
+ "cfg-if",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -278,24 +285,9 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-epoch 0.9.5",
- "crossbeam-utils 0.8.5",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
-dependencies = [
- "autocfg",
- "cfg-if 0.1.10",
- "crossbeam-utils 0.7.2",
- "lazy_static",
- "maybe-uninit",
- "memoffset 0.5.6",
- "scopeguard",
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -304,33 +296,21 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
 dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils 0.8.5",
+ "cfg-if",
+ "crossbeam-utils",
  "lazy_static",
- "memoffset 0.6.4",
+ "memoffset",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.2.3"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
+checksum = "9b10ddc024425c88c2ad148c1b0fd53f4c6d38db9697c9f1588381212fa657c9"
 dependencies = [
- "cfg-if 0.1.10",
- "crossbeam-utils 0.7.2",
- "maybe-uninit",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
-dependencies = [
- "autocfg",
- "cfg-if 0.1.10",
- "lazy_static",
+ "cfg-if",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -339,7 +319,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "lazy_static",
 ]
 
@@ -377,7 +357,7 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -387,32 +367,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
 
 [[package]]
-name = "derefable"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e519abf1289075763071c981958e89948b079fc54962617a0e6413d9ce44cbe7"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
-]
-
-[[package]]
 name = "derive-new"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3418329ca0ad70234b9735dc4ceed10af4df60eff9c8e7b06cb5e520d92c3535"
 dependencies = [
- "proc-macro2 1.0.27",
- "quote 1.0.9",
- "syn 1.0.73",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
-
-[[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "either"
@@ -436,16 +399,16 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5c450cf304c9e18d45db562025a14fb1ca0f5c769b6f609309f81d4c31de455"
 dependencies = [
- "proc-macro2 1.0.27",
- "quote 1.0.9",
- "syn 1.0.73",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "env_logger"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
 dependencies = [
  "atty",
  "humantime",
@@ -472,10 +435,24 @@ version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd3aec53de10fe96d7d8c565eb17f2c687bb5518a2ec453b5b1252964526abe0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crc32fast",
  "libc",
+ "libz-sys",
  "miniz_oxide",
+]
+
+[[package]]
+name = "flume"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24c3fd473b3a903a62609e413ed7538f99e10b665ecb502b5e481a95283f8ab4"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "pin-project",
+ "spin",
 ]
 
 [[package]]
@@ -500,8 +477,20 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fc7a9dc005c944c98a935e7fd626faf5bf7e5a609f94bc13e42fc4a02e52593"
 dependencies = [
- "quick-error",
+ "quick-error 1.2.3",
 ]
+
+[[package]]
+name = "futures-core"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
 
 [[package]]
 name = "fxhash"
@@ -518,7 +507,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -529,9 +518,11 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -540,9 +531,9 @@ version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bb3f5b7d8d70c9bd23cf29b2b38094661418fb0ea79f1b0cc2019a11d6f5429"
 dependencies = [
- "proc-macro2 1.0.27",
- "quote 1.0.9",
- "syn 1.0.73",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -582,6 +573,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "gzp"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20dd0d7a649f92279427746e20f343fe79e3c12907d61913c4b238e4db97f114"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "core_affinity",
+ "flate2",
+ "flume",
+ "libdeflater",
+ "libz-sys",
+ "num_cpus",
+ "thiserror",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,9 +615,9 @@ dependencies = [
 
 [[package]]
 name = "hts-sys"
-version = "1.11.1-fix2"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c05850ae977fad8985689e9bfa2720e6ea5a07b55c1fcf11e9d2f187a97ea8"
+checksum = "72c443906f4bac8b8cfe67e4e9d9ca83a454b70a092e1764133d19d5c5c7c1e2"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -623,12 +631,9 @@ dependencies = [
 
 [[package]]
 name = "humantime"
-version = "1.3.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
-]
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "idna"
@@ -659,9 +664,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
 dependencies = [
  "either",
 ]
@@ -691,6 +696,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -703,12 +727,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
 
 [[package]]
+name = "libdeflate-sys"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09c81cf7b5510a30d8a1149dcca5fe85715475a05092c786e660edc72dbf24e4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "libdeflater"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11c0c8321257b64709e8ee6811d0b4a2ce030806e7ce1f36094bfa2c1de1540"
+dependencies = [
+ "libdeflate-sys",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
 dependencies = [
  "cc",
+ "cmake",
  "libc",
  "pkg-config",
  "vcpkg",
@@ -721,12 +764,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfae20f6b19ad527b550c223fddc3077a547fc70cda94b9b566575423fd303ee"
 
 [[package]]
+name = "lock_api"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -762,25 +814,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
-
-[[package]]
 name = "memchr"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
-
-[[package]]
-name = "memoffset"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "memoffset"
@@ -811,6 +848,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nanorand"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "729eb334247daa1803e0a094d0a5c55711b85571179f5ec6e53eccfdf7008958"
+dependencies = [
+ "getrandom 0.2.3",
+]
+
+[[package]]
 name = "ndarray"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,23 +876,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac8cd24d9f185bb7223958d8c1ff7a961b74b1953fd05dba7cc568a63b3861ec"
 dependencies = [
  "rustc_version 0.1.7",
-]
-
-[[package]]
-name = "noodles"
-version = "0.1.0"
-source = "git+https://github.com/zaeleus/noodles.git#a190b6539ea23ea6b929dcbfb3ffa9b1bd66d41b"
-dependencies = [
- "noodles-bgzf",
-]
-
-[[package]]
-name = "noodles-bgzf"
-version = "0.1.0"
-source = "git+https://github.com/zaeleus/noodles.git#a190b6539ea23ea6b929dcbfb3ffa9b1bd66d41b"
-dependencies = [
- "byteorder",
- "flate2",
 ]
 
 [[package]]
@@ -927,15 +956,15 @@ dependencies = [
  "anyhow",
  "bio",
  "crossbeam",
- "crossbeam-channel 0.4.4",
+ "crossbeam-channel",
  "csv",
  "env_logger",
  "grep-cli",
+ "gzp",
  "itertools",
  "lazy_static",
  "log",
  "lru_time_cache",
- "noodles",
  "num_cpus",
  "proptest",
  "rayon",
@@ -966,6 +995,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "576bc800220cc65dac09e99e97b08b358cfab6e17078de8dc5fee223bd2d0c08"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -984,9 +1033,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.27",
- "quote 1.0.9",
- "syn 1.0.73",
+ "proc-macro2",
+ "quote",
+ "syn",
  "version_check",
 ]
 
@@ -996,18 +1045,9 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.27",
- "quote 1.0.9",
+ "proc-macro2",
+ "quote",
  "version_check",
-]
-
-[[package]]
-name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-dependencies = [
- "unicode-xid 0.1.0",
 ]
 
 [[package]]
@@ -1016,23 +1056,23 @@ version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
 dependencies = [
- "unicode-xid 0.2.2",
+ "unicode-xid",
 ]
 
 [[package]]
 name = "proptest"
-version = "0.10.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12e6c80c1139113c28ee4670dc50cc42915228b51f56a9e407f0ec60f966646f"
+checksum = "1e0d9cc07f18492d879586c92b485def06bc850da3118075cd45d50e9c95b0e5"
 dependencies = [
  "bit-set",
  "bitflags",
  "byteorder",
  "lazy_static",
  "num-traits",
- "quick-error",
- "rand 0.7.3",
- "rand_chacha 0.2.2",
+ "quick-error 2.0.1",
+ "rand 0.8.4",
+ "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -1046,13 +1086,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
-name = "quote"
-version = "0.6.13"
+name = "quick-error"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-dependencies = [
- "proc-macro2 0.4.30",
-]
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -1060,7 +1097,7 @@ version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
- "proc-macro2 1.0.27",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -1146,11 +1183,11 @@ dependencies = [
 
 [[package]]
 name = "rand_xorshift"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core 0.5.1",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -1166,7 +1203,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
 dependencies = [
  "autocfg",
- "crossbeam-deque 0.8.0",
+ "crossbeam-deque",
  "either",
  "rayon-core",
 ]
@@ -1177,9 +1214,9 @@ version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
 dependencies = [
- "crossbeam-channel 0.5.1",
- "crossbeam-deque 0.8.0",
- "crossbeam-utils 0.8.5",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
  "lazy_static",
  "num_cpus",
 ]
@@ -1222,31 +1259,31 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
 name = "rstest"
-version = "0.6.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec448bc157977efdc0a71369cf923915b0c4806b1b2449c3fb011071d6f7c38"
+checksum = "2288c66aeafe3b2ed227c981f364f9968fa952ef0b30e84ada4486e7ee24d00a"
 dependencies = [
- "cfg-if 0.1.10",
- "proc-macro2 1.0.27",
- "quote 1.0.9",
- "rustc_version 0.2.3",
- "syn 1.0.73",
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.0",
+ "syn",
 ]
 
 [[package]]
 name = "rust-htslib"
-version = "0.36.0"
+version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2e5f7980deaf4f41366a5b0d51c2cadaf8639bb12d1258fdab87f37007bd9"
+checksum = "2aca6626496389f6e015e25433b85e2895ad3644b44de91167d847bf2d8c1a1c"
 dependencies = [
  "bio-types",
+ "byteorder",
  "custom_derive",
- "derefable",
  "derive-new",
  "hts-sys",
  "ieee754",
@@ -1255,16 +1292,15 @@ dependencies = [
  "linear-map",
  "newtype_derive",
  "regex",
- "strum_macros 0.20.1",
  "thiserror",
  "url",
 ]
 
 [[package]]
 name = "rust-lapper"
-version = "0.5.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45d175cc39d77dc9a48d657e35ab09bdf4e0566b1e09b6cd644ab5463850162c"
+checksum = "dc3ecb80c8c2e28bafde6b2ea4abb68c92c474364e530d97db70203395b8af0a"
 dependencies = [
  "num-traits",
 ]
@@ -1280,11 +1316,11 @@ dependencies = [
 
 [[package]]
 name = "rustc_version"
-version = "0.2.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 0.9.0",
+ "semver 1.0.4",
 ]
 
 [[package]]
@@ -1294,7 +1330,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
 dependencies = [
  "fnv",
- "quick-error",
+ "quick-error 1.2.3",
  "tempfile",
  "wait-timeout",
 ]
@@ -1328,18 +1364,9 @@ checksum = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
 
 [[package]]
 name = "semver"
-version = "0.9.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "serde"
@@ -1356,9 +1383,9 @@ version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
 dependencies = [
- "proc-macro2 1.0.27",
- "quote 1.0.9",
- "syn 1.0.73",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1372,24 +1399,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "snafu"
-version = "0.6.10"
+name = "spin"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab12d3c261b2308b0d80c26fffb58d17eba81a4be97890101f416b478c79ca7"
+checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
 dependencies = [
- "doc-comment",
- "snafu-derive",
-]
-
-[[package]]
-name = "snafu-derive"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1508efa03c362e23817f96cde18abed596a25219a8b2c66e8db33c03543d315b"
-dependencies = [
- "proc-macro2 1.0.27",
- "quote 1.0.9",
- "syn 1.0.73",
+ "lock_api",
 ]
 
 [[package]]
@@ -1432,9 +1447,9 @@ checksum = "7813934aecf5f51a54775e00068c237de98489463968231a51746bbbc03f9c10"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.27",
- "quote 1.0.9",
- "syn 1.0.73",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1445,37 +1460,14 @@ checksum = "57bd81eb48f4c437cadc685403cad539345bf703d78e63707418431cecd4522b"
 
 [[package]]
 name = "strum_macros"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87c85aa3f8ea653bfd3ddf25f7ee357ee4d204731f6aa9ad04002306f6e2774c"
-dependencies = [
- "heck",
- "proc-macro2 1.0.27",
- "quote 1.0.9",
- "syn 1.0.73",
-]
-
-[[package]]
-name = "strum_macros"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee8bc6b87a5112aeeab1f4a9f7ab634fe6cbefc4850006df31267f4cfb9e3149"
 dependencies = [
  "heck",
- "proc-macro2 1.0.27",
- "quote 1.0.9",
- "syn 1.0.73",
-]
-
-[[package]]
-name = "syn"
-version = "0.15.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "unicode-xid 0.1.0",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1484,9 +1476,9 @@ version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
 dependencies = [
- "proc-macro2 1.0.27",
- "quote 1.0.9",
- "unicode-xid 0.2.2",
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1495,12 +1487,12 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "rand 0.8.4",
  "redox_syscall",
  "remove_dir_all",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1536,9 +1528,9 @@ version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
 dependencies = [
- "proc-macro2 1.0.27",
- "quote 1.0.9",
- "syn 1.0.73",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1591,12 +1583,6 @@ name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
-
-[[package]]
-name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "unicode-xid"
@@ -1659,6 +1645,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
+
+[[package]]
+name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1667,6 +1713,12 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -1680,7 +1732,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,28 +25,29 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0.41"
-bio = "0.32.0"
-crossbeam = "0.7.3"
-crossbeam-channel = "0.4.4"
+bio = "0.39.0"
+crossbeam = "0.8.1"
+crossbeam-channel = "0.5.1"
 csv = "1.1.6"
-env_logger = "0.7.1"
+env_logger = "0.9.0"
 grep-cli = "0.1.5"
-itertools = "0.9.0"
+gzp = "0.9.2"
+itertools = "0.10.1"
 lazy_static = "1.4.0"
 log = "0.4.11"
 lru_time_cache = "0.11.1"
-noodles = { version = "0.1.0", git = "https://github.com/zaeleus/noodles.git", features = ["bgzf"] }
 num_cpus = "1.13.0"
 rayon = "1.4.0"
-rust-htslib = "0.36"
-rust-lapper = "0.5.0"
+#TODO add  features = ["libdeflate"] when https://github.com/rust-bio/rust-htslib/pull/341 is merged
+rust-htslib = {version = "0.38"}
+rust-lapper = "1.0.0"
 serde = { version = "1.0.116", features = ["derive"] }
 smartstring = { version = "0.2.4", features = ["serde"] }
 structopt = "0.3.18"
 termcolor = "1.1.0"
 
 [dev-dependencies]
-proptest = "0.10.1"
-rstest = "0.6.4"
+proptest = "1.0.0"
+rstest = "0.11.0"
 tempfile = "3.1.0"
 

--- a/README.md
+++ b/README.md
@@ -93,11 +93,29 @@ USAGE:
     perbase base-depth [FLAGS] [OPTIONS] <reads>
 
 FLAGS:
-    -Z, --bgzip        Optionally bgzip the output
-    -h, --help         Prints help information
-    -m, --mate-fix     Fix overlapping mates counts, see docs for full details
-    -V, --version      Prints version information
-    -z, --zero-base    Output positions as 0-based instead of 1-based
+    -Z, --bgzip                     
+            Optionally bgzip the output
+
+    -h, --help                      
+            Prints help information
+
+    -k, --keep-zeros                
+            Keep positions even if they have 0 depth
+
+    -m, --mate-fix                  
+            Fix overlapping mates counts, see docs for full details
+
+    -M, --skip-merging-intervals    
+            Skip mergeing togther regions specified in the optional BED or BCF/VCF files.
+            
+            **NOTE** If this is set it could result in duplicate output entries for regions that overlap. **NOTE** This
+            may cause issues with downstream tooling.
+    -V, --version                   
+            Prints version information
+
+    -z, --zero-base                 
+            Output positions as 0-based instead of 1-based
+
 
 OPTIONS:
     -B, --bcf-file <bcf-file>
@@ -112,24 +130,43 @@ OPTIONS:
     -c, --chunksize <chunksize>
             The ideal number of basepairs each worker receives. Total bp in memory at one time is (threads - 2) *
             chunksize [default: 1000000]
-    -F, --exclude-flags <exclude-flags>                      SAM flags to exclude, recommended 3848 [default: 0]
-    -f, --include-flags <include-flags>                      SAM flags to include [default: 0]
+    -L, --compression-level <compression-level>
+            The level to use for compressing output (specified by --bgzip) [default: 2]
+
+    -T, --compression-threads <compression-threads>
+            The number of threads to use for compressing output (specified by --bgzip) [default: 4]
+
+    -F, --exclude-flags <exclude-flags>                      
+            SAM flags to exclude, recommended 3848 [default: 0]
+
+    -f, --include-flags <include-flags>                      
+            SAM flags to include [default: 0]
+
     -D, --max-depth <max-depth>
             Set the max depth for a pileup. If a positions depth is within 1% of max-depth the `NEAR_MAX_DEPTH` output
             field will be set to true and that position should be viewed as suspect [default: 100000]
     -Q, --min-base-quality-score <min-base-quality-score>
             Minium base quality for a base to be counted toward [A, C, T, G]. If the base is less than the specified
             quality score it will instead be counted as an `N`. If nothing is set for this no cutoff will be applied
-    -q, --min-mapq <min-mapq>                                Minimum MAPQ for a read to count toward depth [default: 0]
-    -o, --output <output>                                    Output path, defaults to stdout
+    -q, --min-mapq <min-mapq>                                
+            Minimum MAPQ for a read to count toward depth [default: 0]
+
+    -o, --output <output>                                    
+            Output path, defaults to stdout
+
         --ref-cache-size <ref-cache-size>
             Number of Reference Sequences to hold in memory at one time. Smaller will decrease mem usage [default: 10]
 
-    -r, --ref-fasta <ref-fasta>                              Indexed reference fasta, set if using CRAM
-    -t, --threads <threads>                                  The number of threads to use [default: 32]
+    -r, --ref-fasta <ref-fasta>                              
+            Indexed reference fasta, set if using CRAM
+
+    -t, --threads <threads>                                  
+            The number of threads to use [default: 32]
+
 
 ARGS:
-    <reads>    Input indexed BAM/CRAM to analyze
+    <reads>    
+            Input indexed BAM/CRAM to analyze
 ```
 
 ### only-depth
@@ -179,15 +216,38 @@ USAGE:
     perbase only-depth [FLAGS] [OPTIONS] <reads>
 
 FLAGS:
-        --bed-format    Output BED-like output format with the depth in the 5th column. Note, `-z` can be used with this
-                        to change coordinates to 0-based to be more BED-like
-    -Z, --bgzip         Optionally bgzip the output
-    -x, --fast-mode     Calculate depth based only on read starts/stops, see docs for full details
-    -h, --help          Prints help information
-    -m, --mate-fix      Fix overlapping mates counts, see docs for full details
-    -n, --no-merge      Skip merging adjacent bases that have the same depth
-    -V, --version       Prints version information
-    -z, --zero-base     Output positions as 0-based instead of 1-based
+        --bed-format                
+            Output BED-like output format with the depth in the 5th column. Note, `-z` can be used with this to change
+            coordinates to 0-based to be more BED-like
+    -Z, --bgzip                     
+            Optionally bgzip the output
+
+    -x, --fast-mode                 
+            Calculate depth based only on read starts/stops, see docs for full details
+
+    -h, --help                      
+            Prints help information
+
+    -k, --keep-zeros                
+            Keep positions even if they have 0 depth
+
+    -m, --mate-fix                  
+            Fix overlapping mates counts, see docs for full details
+
+    -n, --no-merge                  
+            Skip merging adjacent bases that have the same depth
+
+    -M, --skip-merging-intervals    
+            Skip mergeing togther regions specified in the optional BED or BCF/VCF files.
+            
+            **NOTE** If this is set it could result in duplicate output entries for regions that overlap. **NOTE** This
+            may cause issues with downstream tooling.
+    -V, --version                   
+            Prints version information
+
+    -z, --zero-base                 
+            Output positions as 0-based instead of 1-based
+
 
 OPTIONS:
     -B, --bcf-file <bcf-file>
@@ -203,15 +263,34 @@ OPTIONS:
     -c, --chunksize <chunksize>
             The ideal number of basepairs each worker receives. Total bp in memory at one time is (threads - 2) *
             chunksize [default: 1000000]
-    -F, --exclude-flags <exclude-flags>                    SAM flags to exclude, recommended 3848 [default: 0]
-    -f, --include-flags <include-flags>                    SAM flags to include [default: 0]
-    -q, --min-mapq <min-mapq>                              Minimum MAPQ for a read to count toward depth [default: 0]
-    -o, --output <output>                                  Output path, defaults to stdout
-    -r, --ref-fasta <ref-fasta>                            Indexed reference fasta, set if using CRAM
-    -t, --threads <threads>                                The number of threads to use [default: 16]
+    -L, --compression-level <compression-level>
+            The level to use for compressing output (specified by --bgzip) [default: 2]
+
+    -T, --compression-threads <compression-threads>
+            The number of threads to use for compressing output (specified by --bgzip) [default: 4]
+
+    -F, --exclude-flags <exclude-flags>                    
+            SAM flags to exclude, recommended 3848 [default: 0]
+
+    -f, --include-flags <include-flags>                    
+            SAM flags to include [default: 0]
+
+    -q, --min-mapq <min-mapq>                              
+            Minimum MAPQ for a read to count toward depth [default: 0]
+
+    -o, --output <output>                                  
+            Output path, defaults to stdout
+
+    -r, --ref-fasta <ref-fasta>                            
+            Indexed reference fasta, set if using CRAM
+
+    -t, --threads <threads>                                
+            The number of threads to use [default: 32]
+
 
 ARGS:
-    <reads>    Input indexed BAM/CRAM to analyze
+    <reads>    
+            Input indexed BAM/CRAM to analyze
 ```
 
 ## merge-adjacent
@@ -233,6 +312,8 @@ Or it can take files with three columns with headers that are like
 The `END|chromEnd` column is optional.
 
 ```text
+perbase-merge-adjacent 0.7.5-alpha.0
+Seth Stadick <sstadick@gmail.com>
 Merge adjacent intervals that have the same depth. Input must be sorted like: `sort -k1,1 -k2,2n in.bed > in.sorted.bed`
 
 Generally accepts any file with no header tha is <chrom>\t<start>\t<stop>\t<depth>. The <stop> is optional. See
@@ -242,16 +323,33 @@ USAGE:
     perbase merge-adjacent [FLAGS] [OPTIONS] [in-file]
 
 FLAGS:
-    -Z, --bgzip        Optionally bgzip the output
-    -h, --help         Prints help information
-    -n, --no-header    Indicate if the input file does not have a header
-    -V, --version      Prints version information
+    -Z, --bgzip        
+            Optionally bgzip the output
+
+    -h, --help         
+            Prints help information
+
+    -n, --no-header    
+            Indicate if the input file does not have a header
+
+    -V, --version      
+            Prints version information
+
 
 OPTIONS:
-    -o, --output <output>    The output location, defaults to STDOUT
+    -T, --compression-level <compression-level>
+            The level to use for compressing output (specified by --bgzip) [default: 2]
+
+    -T, --compression-threads <compression-threads>
+            The number of threads to use for compressing output (specified by --bgzip) [default: 32]
+
+    -o, --output <output>                              
+            The output location, defaults to STDOUT
+
 
 ARGS:
-    <in-file>    Input bed-like file, defaults to STDIN
+    <in-file>    
+            Input bed-like file, defaults to STDIN
 ```
 
 EX:

--- a/examples/par_granges_example.rs
+++ b/examples/par_granges_example.rs
@@ -93,6 +93,7 @@ fn main() -> Result<()> {
         None,                                 // optional ref fasta
         None, // optional bcf/vcf file to specify positions of interest
         Some(PathBuf::from("test/test.bed")), // bedfile to narrow regions
+        true, // Merge any overlapping regions in the BED file
         None, // optional allowed number of threads, defaults to max
         None, // optional chunksize modification
         None, // optional modifier on the size of the channel for sending Positions

--- a/src/commands/base_depth.rs
+++ b/src/commands/base_depth.rs
@@ -72,6 +72,13 @@ pub struct BaseDepth {
     #[structopt(long, short = "k")]
     keep_zeros: bool,
 
+    /// Skip mergeing togther regions specified in the optional BED or BCF/VCF files.
+    ///
+    /// **NOTE** If this is set it could result in duplicate output entries for regions that overlap.
+    /// **NOTE** This may cause issues with downstream tooling.
+    #[structopt(long, short = "M")]
+    skip_merging_intervals: bool,
+
     /// Minimum MAPQ for a read to count toward depth.
     #[structopt(long, short = "q", default_value = "0")]
     min_mapq: u8,
@@ -121,6 +128,7 @@ impl BaseDepth {
             self.ref_fasta.clone(),
             self.bed_file.clone(),
             self.bcf_file.clone(),
+            !self.skip_merging_intervals,
             Some(cpus),
             Some(self.chunksize),
             Some(self.channel_size_modifier),
@@ -399,6 +407,7 @@ mod tests {
             None,
             None,
             None,
+            true,
             Some(cpus),
             None,
             Some(0.001),
@@ -441,6 +450,7 @@ mod tests {
             None,
             None,
             None,
+            true,
             Some(cpus),
             None,
             Some(0.001),
@@ -483,6 +493,7 @@ mod tests {
             None,
             None,
             None,
+            true,
             Some(cpus),
             None,
             Some(0.001),
@@ -525,6 +536,7 @@ mod tests {
             None,
             None,
             None,
+            true,
             Some(cpus),
             None,
             Some(0.001),

--- a/src/commands/base_depth.rs
+++ b/src/commands/base_depth.rs
@@ -52,7 +52,7 @@ pub struct BaseDepth {
     compression_threads: usize,
 
     /// The level to use for compressing output (specified by --bgzip)
-    #[structopt(long, short = "T", default_value = "2")]
+    #[structopt(long, short = "L", default_value = "2")]
     compression_level: u32,
 
     /// The ideal number of basepairs each worker receives. Total bp in memory at one time is (threads - 2) * chunksize.

--- a/src/commands/base_depth.rs
+++ b/src/commands/base_depth.rs
@@ -269,20 +269,19 @@ impl<F: ReadFilter> RegionProcessor for BaseProcessor<F> {
 
         if self.keep_zeros {
             let mut new_result = vec![];
+            let name = PileupPosition::compact_refseq(&header, tid);
+            let mut pos = start;
             if let Some(position) = result.get(0) {
-                let mut pos = start;
-                while position.pos > pos {
-                    let name = PileupPosition::compact_refseq(&header, tid);
-                    new_result.push(PileupPosition::new(name, pos + self.coord_base));
+                while pos < (position.pos - self.coord_base) {
+                    new_result.push(PileupPosition::new(name.clone(), pos + self.coord_base));
                     pos += 1;
                 }
                 pos += result.len() as u32;
                 new_result.extend(result.into_iter());
-                while pos < stop {
-                    let name = PileupPosition::compact_refseq(&header, tid);
-                    new_result.push(PileupPosition::new(name, pos + self.coord_base));
-                    pos += 1;
-                }
+            }
+            while pos < stop {
+                new_result.push(PileupPosition::new(name.clone(), pos + self.coord_base));
+                pos += 1;
             }
             new_result
         } else {

--- a/src/commands/merge_adjacent.rs
+++ b/src/commands/merge_adjacent.rs
@@ -22,7 +22,7 @@ pub struct MergeAdjacent {
     compression_threads: usize,
 
     /// The level to use for compressing output (specified by --bgzip)
-    #[structopt(long, short = "T", default_value = "2")]
+    #[structopt(long, short = "L", default_value = "2")]
     compression_level: u32,
 
     /// Indicate if the input file does not have a header

--- a/src/commands/merge_adjacent.rs
+++ b/src/commands/merge_adjacent.rs
@@ -17,6 +17,14 @@ pub struct MergeAdjacent {
     /// Input bed-like file, defaults to STDIN.
     in_file: Option<PathBuf>,
 
+    /// The number of threads to use for compressing output (specified by --bgzip)
+    #[structopt(long, short = "T", default_value = utils::NUM_CPU.as_str())]
+    compression_threads: usize,
+
+    /// The level to use for compressing output (specified by --bgzip)
+    #[structopt(long, short = "T", default_value = "2")]
+    compression_level: u32,
+
     /// Indicate if the input file does not have a header
     #[structopt(long, short = "n")]
     no_header: bool,
@@ -40,7 +48,13 @@ impl MergeAdjacent {
                 .map(utils::is_bgzipped)
                 .unwrap_or(false),
         )?;
-        let mut writer = utils::get_writer(&self.output, self.bgzip, true)?;
+        let mut writer = utils::get_writer(
+            &self.output,
+            self.bgzip,
+            true,
+            self.compression_threads,
+            self.compression_level,
+        )?;
         let mut iter = reader.deserialize().map(|r| {
             let rec: BedLike = r.expect("Deserialzied record");
             rec

--- a/src/commands/only_depth.rs
+++ b/src/commands/only_depth.rs
@@ -59,11 +59,11 @@ pub struct OnlyDepth {
     threads: usize,
 
     /// The number of threads to use for compressing output (specified by --bgzip)
-    #[structopt(long, short = "t", default_value = "4")]
+    #[structopt(long, short = "T", default_value = "4")]
     compression_threads: usize,
 
     /// The level to use for compressing output (specified by --bgzip)
-    #[structopt(long, short = "T", default_value = "2")]
+    #[structopt(long, short = "L", default_value = "2")]
     compression_level: u32,
 
     /// The ideal number of basepairs each worker receives. Total bp in memory at one time is (threads - 2) * chunksize.

--- a/src/commands/only_depth.rs
+++ b/src/commands/only_depth.rs
@@ -86,6 +86,13 @@ pub struct OnlyDepth {
     #[structopt(long, short = "n")]
     no_merge: bool,
 
+    /// Skip mergeing togther regions specified in the optional BED or BCF/VCF files.
+    ///
+    /// **NOTE** If this is set it could result in duplicate output entries for regions that overlap.
+    /// **NOTE** This may cause issues with downstream tooling.
+    #[structopt(long, short = "M")]
+    skip_merging_intervals: bool,
+
     /// Keep positions even if they have 0 depth.
     #[structopt(long, short = "k")]
     keep_zeros: bool,
@@ -124,6 +131,7 @@ impl OnlyDepth {
             self.ref_fasta.clone(),
             self.bed_file.clone(),
             self.bcf_file.clone(),
+            !self.skip_merging_intervals,
             Some(cpus),
             Some(self.chunksize.clone()),
             Some(self.channel_size_modifier),
@@ -653,6 +661,7 @@ mod tests {
             None,
             None,
             None,
+            true,
             Some(cpus),
             Some(1_000_000),
             Some(0.001),
@@ -693,6 +702,7 @@ mod tests {
             None,
             None,
             None,
+            true,
             Some(cpus),
             Some(1_000_000),
             Some(0.001),
@@ -733,6 +743,7 @@ mod tests {
             None,
             None,
             None,
+            true,
             Some(cpus),
             Some(1_000_000),
             Some(0.001),
@@ -773,6 +784,7 @@ mod tests {
             None,
             None,
             None,
+            true,
             Some(cpus),
             None,
             Some(0.001),
@@ -813,6 +825,7 @@ mod tests {
             None,
             None,
             None,
+            true,
             Some(cpus),
             None,
             Some(0.001),

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -100,6 +100,7 @@
 //!         None,                                 // optional ref fasta
 //!         None,                                 // optional bcf/vcf file specifying positions of interest
 //!         Some(PathBuf::from("test/test.bed")), // bedfile to narrow regions
+//!         true,                                 // merge any overlapping intervals in the BED file
 //!         None,                                 // optional allowed number of threads, defaults to max
 //!         None,                                 // optional chunksize modification
 //!         None,                                 // optional channel size modification

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -119,7 +119,7 @@
 //! }
 //!```
 #![warn(missing_docs)]
-#![warn(missing_doc_code_examples)]
+#![warn(rustdoc::missing_doc_code_examples)]
 pub mod par_granges;
 pub mod position;
 pub mod read_filter;

--- a/src/lib/par_granges.rs
+++ b/src/lib/par_granges.rs
@@ -452,9 +452,9 @@ mod test {
                 chr_rec.push_tag(b"LN", &chr.2.to_string()); // set len as max observed
                 header.push_record(&chr_rec);
             }
-            let writer = bam::Writer::from_path(&bam_path, &header, bam::Format::BAM).expect("Opened test.bam for writing");
+            let writer = bam::Writer::from_path(&bam_path, &header, bam::Format::Bam).expect("Opened test.bam for writing");
             drop(writer); // force flush the writer so the header info is written
-            bam::index::build(&bam_path, None, bam::index::Type::BAI, 1).unwrap();
+            bam::index::build(&bam_path, None, bam::index::Type::Bai, 1).unwrap();
 
             // Build a bed
             let mut writer = bed::Writer::to_file(&bed_path).expect("Opened test.bed for writing");
@@ -476,7 +476,7 @@ mod test {
             for (i,chr) in chromosomes.iter().enumerate() {
                 header.push_record(format!("##contig=<ID={},length={}>", &i.to_string(), &chr.2.to_string()).as_bytes());
             }
-            let mut writer = bcf::Writer::from_path(&vcf_path, &header, true, bcf::Format::VCF).expect("Failed to open test.vcf for writing");
+            let mut writer = bcf::Writer::from_path(&vcf_path, &header, true, bcf::Format::Vcf).expect("Failed to open test.vcf for writing");
             let mut record = writer.empty_record();
             for (i, chr) in chromosomes.iter().enumerate() {
                 record.set_rid(Some(i as u32));

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,7 @@ impl Subcommand {
 }
 
 fn main() -> Result<()> {
-    env_logger::from_env(Env::default().default_filter_or("info")).init();
+    env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
     if let Err(err) = Args::from_args().subcommand.run() {
         if utils::is_broken_pipe(&err) {
             std::process::exit(0);


### PR DESCRIPTION
Adds:
- `--keep-zeros`: Don't truncate outputs by omitting locations with 0 depth
- `skip-merging-intervals`: If a BED or VCF/BCF file is provided, don't merge the intervals found within, this will produce duplicate entries. This is useful in some niche cases when looking at fixed windows around sites that are then fed into matrices.
- Fix error messages for invalid BED records https://github.com/sstadick/perbase/issues/42
- Update all deps, which fixes https://github.com/sstadick/perbase/issues/41 since rust-bio no handles variable widths BED files
- Move to `gzp` instead of noodles for bgzf support for reading and writing. Now supports multi-threaded writer