### PR TITLE
WIP: Mate fix efficient

### DIFF
--- a/examples/par_granges_example.rs
+++ b/examples/par_granges_example.rs
@@ -5,7 +5,7 @@ use perbase_lib::{
     position::pileup_position::PileupPosition,
     read_filter::ReadFilter,
 };
-use rust_htslib::bam::{self, record::Record, Read};
+use rust_htslib::bam::{self, pileup::Alignment, record::Record, Read};
 use std::path::PathBuf;
 
 // To use ParGranges you will need to implement a [`RegionProcessor`](par_granges::RegionProcessor),
@@ -32,7 +32,7 @@ struct BasicReadFilter {
 impl ReadFilter for BasicReadFilter {
     // Filter reads based SAM flags and mapping quality, true means pass
     #[inline]
-    fn filter_read(&self, read: &Record) -> bool {
+    fn filter_read(&self, read: &Record, _alignment: Option<&Alignment>) -> bool {
         let flags = read.flags();
         (!flags) & &self.include_flags == 0
             && flags & &self.exclude_flags == 0

--- a/src/commands/only_depth.rs
+++ b/src/commands/only_depth.rs
@@ -307,7 +307,7 @@ impl<F: ReadFilter> OnlyDepthProcessor<F> {
         for record in reader
             .rc_records()
             .map(|r| r.expect("Read record"))
-            .filter(|read| self.read_filter.filter_read(&read))
+            .filter(|read| self.read_filter.filter_read(&read, None))
             .flat_map(|record| IterAlignedBlocks::new(record, self.mate_fix))
         {
             let rec_start = u32::try_from(record.0).expect("check overflow");
@@ -396,7 +396,7 @@ impl<F: ReadFilter> OnlyDepthProcessor<F> {
         for record in reader
             .rc_records()
             .map(|r| r.expect("Read record"))
-            .filter(|read| self.read_filter.filter_read(&read))
+            .filter(|read| self.read_filter.filter_read(&read, None))
         {
             let rec_start = u32::try_from(record.reference_start()).expect("check overflow");
             let rec_stop = u32::try_from(record.reference_end()).expect("check overflow");

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -17,7 +17,7 @@
 //!     position::pileup_position::PileupPosition,
 //!     read_filter::ReadFilter,
 //! };
-//! use rust_htslib::bam::{self, record::Record, Read};
+//! use rust_htslib::bam::{self, record::Record, Read, pileup::Alignment};
 //! use std::path::PathBuf;
 //!
 //! // To use ParGranges you will need to implement a [`RegionProcessor`](par_granges::RegionProcessor),
@@ -44,7 +44,7 @@
 //! impl ReadFilter for BasicReadFilter {
 //!     // Filter reads based SAM flags and mapping quality, true means pass
 //!     #[inline]
-//!     fn filter_read(&self, read: &Record) -> bool {
+//!     fn filter_read(&self, read: &Record, _: Option<&Alignment>) -> bool {
 //!         let flags = read.flags();
 //!         (!flags) & &self.include_flags == 0
 //!             && flags & &self.exclude_flags == 0

--- a/src/lib/position/pileup_position.rs
+++ b/src/lib/position/pileup_position.rs
@@ -72,7 +72,7 @@ impl PileupPosition {
         read_filter: &F,
         base_filter: Option<u8>,
     ) {
-        if !read_filter.filter_read(&record) {
+        if !read_filter.filter_read(&record, Some(alignment)) {
             self.depth -= 1;
             self.fail += 1;
             return;
@@ -201,9 +201,10 @@ impl PileupPosition {
                     Ordering::Less => Ordering::Less,
                     Ordering::Equal => {
                         // Check if a is first in pair
-                        if a.1.flags() & 64 == 0 && read_filter.filter_read(&a.1) {
+                        if a.1.flags() & 64 == 0 && read_filter.filter_read(&a.1, Some(&a.0)) {
                             Ordering::Greater
-                        } else if b.1.flags() & 64 == 0 && read_filter.filter_read(&b.1) {
+                        } else if b.1.flags() & 64 == 0 && read_filter.filter_read(&b.1, Some(&b.0))
+                        {
                             Ordering::Less
                         } else {
                             // Default to `a` in the event that there is no first in pair for some reason

--- a/src/lib/position/pileup_position.rs
+++ b/src/lib/position/pileup_position.rs
@@ -198,15 +198,21 @@ impl PileupPosition {
         });
 
         // Group records by qname
-        for (_qname, reads) in by_name.into_iter() {
+        for (_qname, alignments) in by_name.into_iter() {
             // Choose the best of the reads based on mapq, if tied, check which is first and passes filters
             let mut total_reads = 0; // count how many reads there were
-            let (alignment, record) = reads
+            if alignments.len() == 1 {
+                let aln = &alignments[0];
+                let record = aln.record();
+                Self::update(&mut pos, aln, record, read_filter, base_filter);
+                continue;
+            }
+            let (alignment, record) = alignments
                 .into_iter()
-                .map(|x| {
+                .map(|aln| {
                     total_reads += 1;
-                    let record = x.record();
-                    (x, record)
+                    let record = aln.record();
+                    (aln, record)
                 })
                 .max_by(|a, b| match a.1.mapq().cmp(&b.1.mapq()) {
                     Ordering::Greater => Ordering::Greater,

--- a/src/lib/read_filter.rs
+++ b/src/lib/read_filter.rs
@@ -1,10 +1,11 @@
 //! A trait and default implementation of a read filter.
+use rust_htslib::bam::pileup::Alignment;
 use rust_htslib::bam::record::Record;
 
 /// Anything that implements ReadFilter can apply a filter set to read.
 pub trait ReadFilter {
     /// filters a read, true is pass, false if fail
-    fn filter_read(&self, read: &Record) -> bool;
+    fn filter_read(&self, read: &Record, alignment: Option<&Alignment>) -> bool;
 }
 
 /// A straightforward read filter.
@@ -28,7 +29,7 @@ impl DefaultReadFilter {
 impl ReadFilter for DefaultReadFilter {
     /// Filter reads based SAM flags and mapping quality
     #[inline(always)]
-    fn filter_read(&self, read: &Record) -> bool {
+    fn filter_read(&self, read: &Record, _alignment: Option<&Alignment>) -> bool {
         let flags = read.flags();
         (!flags) & &self.include_flags == 0
             && flags & &self.exclude_flags == 0


### PR DESCRIPTION
I inadvertently built this on top of #61 .
But it tries to only do the expensive operation of mate tracking when there's a possibility that the mates overlap. If we know a given read end falls strictly before the mate then they can't overlap. 
If there is overlap, then they are pushed into a hashmap, there's not sorting or groubpy. 

Still need to benchmark this against the existing impl, but I suspect it should be faster given many overlaps.