### PR TITLE
bump rust-htslib to v0.39 to allow aarch64 build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ lru_time_cache = "0.11.1"
 num_cpus = "1.13.0"
 rayon = "1.4.0"
 #TODO add  features = ["libdeflate"] when https://github.com/rust-bio/rust-htslib/pull/341 is merged
-rust-htslib = {version = "0.38"}
+rust-htslib = {version = "0.39"}
 rust-lapper = "1.0"
 serde = { version = "1.0.116", features = ["derive"] }
 smartstring = { version = "1.0.1", features = ["serde"] }


### PR DESCRIPTION
This PR bumps the rust-htslib  version in Cargo.toml to v0.39 and fixes #77.