### PR TITLE
fix: correct mate selection in --mate-fix to prefer first mate when MAPQ is equal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 0.10.3
+
+- **Bugfix**: Fixed mate selection in `--mate-fix` to correctly prefer first mate over second mate when MAPQ scores are equal (issue #82)
 
 ## 0.8.3
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1021,7 +1021,7 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "perbase"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "bio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perbase"
-version = "0.10.2"
+version = "0.10.3"
 authors = ["Seth Stadick <sstadick@gmail.com>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
Fixes issue #82 where --mate-fix was incorrectly choosing second mate over first mate when MAPQ scores were tied. The bug was in the SAM flag check logic:

- Changed `flags() & 64 == 0` to `flags() & 64 \!= 0` to properly identify first mate
- SAM flag 64 indicates "first segment in template", so `\!= 0` means IS first mate