### PR TITLE
fix: allow empty seqeunce in BAM record in `perbase only-depth`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.2.0
+
+- Fix: Handle BAM records with empty SEQ fields (`*` in SAM format) in `base-depth`. Previously this would cause an out-of-bounds error. Now these reads still count toward depth, and their bases are counted as `N`. ([#92](https://github.com/sstadick/perbase/pull/92) by @ghuls)
+
 ## 1.1.0
 
 - Fix/Feat: For both MapQualBaseQualN and BaseQualMapQualN only resolve to N when the bases are ambiguous, otherwise return the consensus base.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1027,7 +1027,7 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "perbase"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "bio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perbase"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Seth Stadick <sstadick@gmail.com>"]
 edition = "2024"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ You can also download a binary from the [releases](https://github.com/sstadick/p
 
 The `base-depth` tool walks over every position in the BAM/CRAM file and calculates the depth, as well as the number of each nucleotide at the given position. Additionally, it counts the numbers of Ins/Dels at each position.
 
+**Note on empty SEQ records:** BAM records with empty SEQ fields (represented as `*` in SAM format) are handled gracefully. These reads still count toward depth, but since the actual nucleotide cannot be determined, they are counted as `N`.
+
 The output columns are as follows:
 
 | Column         | Description                                                                                        |


### PR DESCRIPTION
Handle empty sequences in BAM record when generating a pileup to fix an out of bound error in `perbase only-depth` when a BAM record does not have an associated sequence (`*` in sequence column in SAM format).

Fixes: https://github.com/sstadick/perbase/issues/91