### PR TITLE
fix: use `setting` instead of `global_settings` for AppSettings

### DIFF
--- a/src/commands/base_depth.rs
+++ b/src/commands/base_depth.rs
@@ -18,7 +18,7 @@ use structopt::{StructOpt, clap::AppSettings};
 
 /// Calculate the depth at each base, per-nucleotide.
 #[derive(StructOpt)]
-#[structopt(author, global_settings = &[AppSettings::ArgRequiredElseHelp])]
+#[structopt(author, setting = AppSettings::ArgRequiredElseHelp)]
 pub struct BaseDepth {
     /// Input indexed BAM/CRAM to analyze.
     reads: PathBuf,

--- a/src/commands/merge_adjacent.rs
+++ b/src/commands/merge_adjacent.rs
@@ -12,7 +12,7 @@ use structopt::{StructOpt, clap::AppSettings};
 /// Generally accepts any file with no header that is <chrom>\t<start>\t<stop>\t<depth>.
 /// The <stop> is optional. See documentation for explanation of headers that are accepted.
 #[derive(StructOpt)]
-#[structopt(author, global_settings = &[AppSettings::ArgRequiredElseHelp])]
+#[structopt(author, setting = AppSettings::ArgRequiredElseHelp)]
 pub struct MergeAdjacent {
     /// Input bed-like file, defaults to STDIN.
     in_file: Option<PathBuf>,

--- a/src/commands/only_depth.rs
+++ b/src/commands/only_depth.rs
@@ -23,7 +23,7 @@ use structopt::{StructOpt, clap::AppSettings};
 
 /// Calculate only the depth at each base.
 #[derive(StructOpt)]
-#[structopt(author, global_settings = &[AppSettings::ArgRequiredElseHelp])]
+#[structopt(author, setting = AppSettings::ArgRequiredElseHelp)]
 pub struct OnlyDepth {
     /// Input indexed BAM/CRAM to analyze.
     reads: PathBuf,

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use perbase_lib::utils;
 use structopt::{StructOpt, clap::AppSettings};
 
 #[derive(StructOpt)]
-#[structopt(rename_all = "kebab-case", author, about, global_settings = &[AppSettings::SubcommandRequiredElseHelp])]
+#[structopt(rename_all = "kebab-case", author, about, setting = AppSettings::SubcommandRequiredElseHelp)]
 /// Commands for generating per-base analysis
 struct Args {
     #[structopt(subcommand)]


### PR DESCRIPTION
The use of `global_settings` causes AppSettings to propagate to all subcommands/substructs, which breaks positional argument parsing.

- https://github.com/Homebrew/homebrew-core/pull/265761